### PR TITLE
No hostname prefix for thumbailUrl

### DIFF
--- a/src/DTO/ContentObjectBuilder.php
+++ b/src/DTO/ContentObjectBuilder.php
@@ -37,7 +37,8 @@ class ContentObjectBuilder
                 $session->getId(),
                 $session->getName(),
                 $session->getDescription() ?? '',
-                'https://' . xpanConfig::getConfig(xpanConfig::F_HOSTNAME) . $session->getThumbUrl(),
+         //       'https://' . xpanConfig::getConfig(xpanConfig::F_HOSTNAME) . $session->getThumbUrl(),
+                $session->getThumbUrl(),
                 $session->getDuration());
         }
         return $sessions_array;


### PR DESCRIPTION
In our case the API return already full URL.  Prefixing hostname leads to error. 